### PR TITLE
fixed depth test

### DIFF
--- a/shaders/glsl/clear.comp
+++ b/shaders/glsl/clear.comp
@@ -26,5 +26,5 @@ void main()
     }
 
     imageStore(renderTarget, id, uvec4(0));
-    imageStore(depthBuffer, id, uvec4(0));
+    imageStore(depthBuffer, id, uvec4(0xFFFFFFFF)); // depth-test assumes maximum depth in empty depth-buffer for atomic-min-operation
 }

--- a/shaders/glsl/projection.comp
+++ b/shaders/glsl/projection.comp
@@ -75,15 +75,13 @@ void main(){
                 const vec2 coords = (projected.xy/projected.w * .5f + .5f) * camera.resolution;
 
                 // depth test via 64-bit-atomicMin
-                const uint depth = uint(floatBitsToInt(projected.w)); // cast instead of floatBitsToUint to avoid problems with negative numbers
+                const uint depth = floatBitsToUint(projected.w);
 
                 const uint oldValue = imageAtomicMin(depthBuffer, ivec2(coords), depth);
 
                 if(depth < oldValue){
 	                imageAtomicExchange(renderTarget, ivec2(coords), points[k].rgba);
                 }
-
-                imageStore(renderTarget, ivec2(coords), uvec4(points[k].rgba));
             }
         }
     }


### PR DESCRIPTION
Depth buffer clear value is now max-uint.
Removed line that accidentally overwrites depth test.

Closes #7.
