### PR TITLE
Distribute one batch per work group

### DIFF
--- a/shaders/glsl/clear.comp
+++ b/shaders/glsl/clear.comp
@@ -16,7 +16,7 @@ layout(set = 0, binding = 1) uniform DynamicConst{
 layout(set = 1, binding = 0, r32ui) writeonly uniform uimage2D renderTarget;
 layout(set = 1, binding = 1, r32ui) writeonly uniform uimage2D depthBuffer;
 
-layout(local_size_x = 128) in;
+layout(local_size_x = 1024) in;
 
 void main()
 {

--- a/shaders/glsl/lod.comp
+++ b/shaders/glsl/lod.comp
@@ -40,7 +40,7 @@ layout(set = 2, binding = 1) readonly buffer BatchList{
     uint batchList[];
 };
 
-layout(local_size_x = 128) in;
+layout(local_size_x = 1024) in;
 
 void main(){
     // TODO: @Atzubi

--- a/shaders/glsl/projection.comp
+++ b/shaders/glsl/projection.comp
@@ -58,7 +58,7 @@ layout(set = 3, binding = 1) readonly buffer BatchList{
     uint batchList[];
 };
 
-layout(local_size_x = 128) in;
+layout(local_size_x = 1024) in;
 
 uint getBatchPixelExtend(const Batch currBatch){
     // determine precision by projecting batch aabb to screen
@@ -119,8 +119,7 @@ vec3 getAdaptivePointPosition(const vec3 batchBoxSize, const vec3 batchBoxMin, c
 }
 
 void main(){
-
-    const uint id = gl_GlobalInvocationID.x;
+    const uint id = gl_GlobalInvocationID.x / gl_WorkGroupSize.x;
     if (id >= batchCount){
         return;
     }
@@ -128,8 +127,13 @@ void main(){
     const Batch batch = batches[batchList[id]];
     const vec3 batchBBSize = batch.box.maxV - batch.box.minV;
     const uint batchPixelExtend = getBatchPixelExtend(batch);
+    const uint localId = gl_LocalInvocationID.x;
+    const uint workAmount = (batch.pointCount / gl_WorkGroupSize.x) + 1;
 
-    for (uint k = batch.pointOffset; k < batch.pointOffset + batch.pointCount; ++k){
+    for (uint k = batch.pointOffset + localId * workAmount; k < batch.pointOffset + (localId + 1) * workAmount; ++k){
+        if ((k - batch.pointOffset) >= batch.pointCount){
+            break;
+        }
 
         const vec4 projected = camera.projection * camera.view * vec4(getAdaptivePointPosition(batchBBSize, batch.box.minV, batchPixelExtend, k), 1);
 

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -4,7 +4,7 @@
 #include <string_view>
 #include <vector>
 
-constexpr auto MaxBatchSize = 8;
+constexpr auto MaxBatchSize = 8192;
 
 struct CompressedPosition {
     std::uint32_t x : 10;

--- a/src/VPCR.cpp
+++ b/src/VPCR.cpp
@@ -10,7 +10,7 @@
 namespace
 {
 // Should match compute shaders
-constexpr std::uint32_t ComputeLaneCount = 128;
+constexpr std::uint32_t ComputeLaneCount = 1024;
 
 class VPCRImpl final : public VPCR {
 public:
@@ -206,9 +206,9 @@ void VPCRImpl::OnRender(std::uint32_t frameIndex)
     const auto res = config_.Get<std::vector<std::uint32_t>>("resolution").value();
     const auto batchCount = pointCloudAcceleration_->GetBatchCount();
     clearPass->Execute(commandRecorder, res[0] / ComputeLaneCount + 1, res[1]);
-    lodPass->Execute(commandRecorder, batchCount / ComputeLaneCount + 1);
+    lodPass->Execute(commandRecorder, batchCount);
     commandRecorder.barrier(tga::PipelineStage::ComputeShader, tga::PipelineStage::ComputeShader);
-    projectionPass->Execute(commandRecorder, batchCount / ComputeLaneCount + 1);
+    projectionPass->Execute(commandRecorder, batchCount);
     commandRecorder.barrier(tga::PipelineStage::ComputeShader, tga::PipelineStage::FragmentShader);
     displayPass->Execute(commandRecorder, frameIndex);
 


### PR DESCRIPTION
The best amount of points per thread seems to be 8 (I'm not sure how they found ~80 was the best in their paper, maybe you want to experiment or have an explanation). Therefore the work group size should be 1/8 of the MaxBatchSize.